### PR TITLE
Create website index for ontologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Ontologies for projects
 3rd party ontologies useful for projects
+
+## Website Generation
+
+Run `scripts/generate_index.py` to produce `docs/ontologies.json`. The `docs` directory hosts a simple index that can be served via GitHub Pages.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ontologies Index</title>
+<meta name="description" content="Index of ontologies for projects">
+<meta name="keywords" content="ontology, project">
+<script>
+async function load() {
+  const resp = await fetch('ontologies.json');
+  const data = await resp.json();
+  window.ontologies = data;
+  render();
+}
+function render() {
+  const filter = document.getElementById('filter').value.toLowerCase();
+  const container = document.getElementById('cards');
+  container.innerHTML = '';
+  ontologies.forEach(o => {
+    if (!filter || o.name.toLowerCase().includes(filter) || o.type.includes(filter)) {
+      const div = document.createElement('div');
+      div.className = 'card';
+      div.innerHTML = `<h3>${o.name}</h3><p>${o.description}</p><p><a href="../${o.file}">${o.file}</a> (${o.type})</p>`;
+      container.appendChild(div);
+    }
+  });
+}
+document.addEventListener('DOMContentLoaded', load);
+</script>
+<style>
+body { font-family: Arial, sans-serif; }
+.card { border: 1px solid #ccc; padding: 1em; margin: 0.5em 0; }
+</style>
+</head>
+<body>
+<h1>Ontologies</h1>
+<input id="filter" placeholder="Filter" oninput="render()">
+<div id="cards"></div>
+</body>
+</html>

--- a/docs/ontologies.json
+++ b/docs/ontologies.json
@@ -1,0 +1,284 @@
+[
+  {
+    "file": "2020BFOeasier.ttl",
+    "type": "ttl",
+    "name": "BFO 2020",
+    "description": ""
+  },
+  {
+    "file": "2020_02_philosophy_inpho.owl",
+    "type": "owl",
+    "name": "2020_02_philosophy_inpho",
+    "description": ""
+  },
+  {
+    "file": "2020_11_Philosphy inpho.owl",
+    "type": "owl",
+    "name": "2020_11_Philosphy inpho",
+    "description": ""
+  },
+  {
+    "file": "2022 11 safety ontology.ttl",
+    "type": "ttl",
+    "name": "2022 11 safety ontology",
+    "description": ""
+  },
+  {
+    "file": "2022 useful ontologies from protege.txt",
+    "type": "txt",
+    "name": "2022 useful ontologies from protege",
+    "description": ""
+  },
+  {
+    "file": "BFO2020.rdf",
+    "type": "rdf",
+    "name": "BFO2020",
+    "description": ""
+  },
+  {
+    "file": "BFO2020_betterlabels.owl",
+    "type": "owl",
+    "name": "BFO 2020",
+    "description": ""
+  },
+  {
+    "file": "Decisions.owl.txt",
+    "type": "txt",
+    "name": "Decisions.owl",
+    "description": ""
+  },
+  {
+    "file": "From_archimate_insurance.owl",
+    "type": "owl",
+    "name": "From_archimate_insurance",
+    "description": ""
+  },
+  {
+    "file": "Innovation0_gi2mo.owl",
+    "type": "owl",
+    "name": "Innovation0_gi2mo",
+    "description": ""
+  },
+  {
+    "file": "IoTFrameworks.ttl.html",
+    "type": "html",
+    "name": "IoTFrameworks.ttl",
+    "description": ""
+  },
+  {
+    "file": "OntoAgile.owl.html",
+    "type": "html",
+    "name": "OntoAgile.owl",
+    "description": ""
+  },
+  {
+    "file": "P6_schema_as_cypher.txt",
+    "type": "txt",
+    "name": "P6_schema_as_cypher",
+    "description": ""
+  },
+  {
+    "file": "SWO software ontology.owl",
+    "type": "owl",
+    "name": "SWO software ontology",
+    "description": ""
+  },
+  {
+    "file": "SafetyOntology.owl",
+    "type": "owl",
+    "name": "SafetyOntology",
+    "description": ""
+  },
+  {
+    "file": "agents.md.txt",
+    "type": "txt",
+    "name": "agents.md",
+    "description": ""
+  },
+  {
+    "file": "bfo-2020.owl",
+    "type": "owl",
+    "name": "bfo-2020",
+    "description": ""
+  },
+  {
+    "file": "bfo_classes_only.owl",
+    "type": "owl",
+    "name": "bfo_classes_only",
+    "description": ""
+  },
+  {
+    "file": "building, planning, zoning, and land use regulation information in Finland.ttl",
+    "type": "ttl",
+    "name": "Kokoontumistilan henkil\u00f6m\u00e4\u00e4r\u00e4",
+    "description": "V\u00e4est\u00f6tietoj\u00e4rjestelm\u00e4\u00e4n tallennettu pysyv\u00e4 rakennustunnus."
+  },
+  {
+    "file": "config.owl",
+    "type": "owl",
+    "name": "config",
+    "description": ""
+  },
+  {
+    "file": "cover for risk and value.ttl.txt",
+    "type": "txt",
+    "name": "Endurant",
+    "description": ""
+  },
+  {
+    "file": "cover.ttl.txt",
+    "type": "txt",
+    "name": "Endurant",
+    "description": ""
+  },
+  {
+    "file": "gistCore11.0.0.ttl",
+    "type": "ttl",
+    "name": "gistCore11.0.0",
+    "description": ""
+  },
+  {
+    "file": "gistCore9.4.0.json",
+    "type": "json",
+    "name": "gistCore9.4.0",
+    "description": ""
+  },
+  {
+    "file": "gistCore9.4.0.rdf",
+    "type": "rdf",
+    "name": "gistCore9.4.0",
+    "description": ""
+  },
+  {
+    "file": "gistCore9.4.0.ttl",
+    "type": "ttl",
+    "name": "gistCore",
+    "description": "Gist is a minimalist upper ontology created by Semantic Arts"
+  },
+  {
+    "file": "inpho_temp.ttl",
+    "type": "ttl",
+    "name": "inpho_temp",
+    "description": ""
+  },
+  {
+    "file": "itpm_CommunicationsManagement.owl",
+    "type": "owl",
+    "name": "itpm_CommunicationsManagement",
+    "description": ""
+  },
+  {
+    "file": "itpm_IT-PMV5.owl",
+    "type": "owl",
+    "name": "itpm_IT-PMV5",
+    "description": ""
+  },
+  {
+    "file": "itpm_IssueConcepts(inwork).owl",
+    "type": "owl",
+    "name": "itpm_IssueConcepts(inwork)",
+    "description": ""
+  },
+  {
+    "file": "itpm_KnowledgeBase.owl",
+    "type": "owl",
+    "name": "itpm_KnowledgeBase",
+    "description": ""
+  },
+  {
+    "file": "itpm_QualityMGMT.owl",
+    "type": "owl",
+    "name": "itpm_QualityMGMT",
+    "description": ""
+  },
+  {
+    "file": "itpm_RuleStructure.owl",
+    "type": "owl",
+    "name": "itpm_RuleStructure",
+    "description": ""
+  },
+  {
+    "file": "itpm_ScopeManagement.owl",
+    "type": "owl",
+    "name": "itpm_ScopeManagement",
+    "description": ""
+  },
+  {
+    "file": "itpm_TimeManagement.owl",
+    "type": "owl",
+    "name": "itpm_TimeManagement",
+    "description": ""
+  },
+  {
+    "file": "kko.owl",
+    "type": "owl",
+    "name": "kko",
+    "description": ""
+  },
+  {
+    "file": "ontouml.ttl.html",
+    "type": "html",
+    "name": "ontouml.ttl",
+    "description": ""
+  },
+  {
+    "file": "pmbok-event.owl",
+    "type": "owl",
+    "name": "pmbok-event",
+    "description": ""
+  },
+  {
+    "file": "pmbok-ref.owl",
+    "type": "owl",
+    "name": "pmbok-ref",
+    "description": ""
+  },
+  {
+    "file": "pmbok-role.owl",
+    "type": "owl",
+    "name": "pmbok-role",
+    "description": ""
+  },
+  {
+    "file": "pmbok4.owl",
+    "type": "owl",
+    "name": "pmbok4",
+    "description": ""
+  },
+  {
+    "file": "super pattern.txt.txt",
+    "type": "txt",
+    "name": "super pattern.txt",
+    "description": ""
+  },
+  {
+    "file": "temporal.xsd.xml",
+    "type": "xml",
+    "name": "temporal.xsd",
+    "description": ""
+  },
+  {
+    "file": "temporal1.xsd.xml",
+    "type": "xml",
+    "name": "temporal1.xsd",
+    "description": ""
+  },
+  {
+    "file": "temporalReferenceSystems.xsd.xml",
+    "type": "xml",
+    "name": "temporalReferenceSystems.xsd",
+    "description": ""
+  },
+  {
+    "file": "temporalTopology.xsd.xml",
+    "type": "xml",
+    "name": "temporalTopology.xsd",
+    "description": ""
+  },
+  {
+    "file": "uniclass1-4.rdf",
+    "type": "rdf",
+    "name": "uniclass1-4",
+    "description": ""
+  }
+]

--- a/docs/taxonomy.ttl
+++ b/docs/taxonomy.ttl
@@ -1,0 +1,6 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+# Placeholder taxonomy that can be expanded as ontologies are added.
+
+<http://example.org/taxonomy> a skos:ConceptScheme ;
+    skos:prefLabel "Ontology Topics" .

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Generate ontology index for GitHub pages."""
+
+import os
+import re
+import json
+
+# file extensions to include
+EXTENSIONS = {'.ttl', '.owl', '.rdf', '.json', '.html', '.txt', '.xml'}
+
+def extract_metadata(path):
+    metadata = {
+        'file': path,
+        'type': os.path.splitext(path)[1].lstrip('.').lower()
+    }
+    try:
+        with open(path, 'r', errors='ignore') as f:
+            content = f.read(4096)
+    except Exception:
+        content = ''
+
+    label_match = re.search(r'rdfs:label\s+["\']([^"\']+)["\']', content)
+    if label_match:
+        metadata['name'] = label_match.group(1)
+    else:
+        metadata['name'] = os.path.splitext(os.path.basename(path))[0]
+
+    desc_match = re.search(r'(?:rdfs:comment|dc:description|dct:description)\s+["\']([^"\']+)["\']', content, re.I)
+    if desc_match:
+        metadata['description'] = desc_match.group(1)
+    else:
+        metadata['description'] = ''
+
+    return metadata
+
+def main():
+    index = []
+    for fname in sorted(os.listdir('.')):
+        ext = os.path.splitext(fname)[1].lower()
+        if ext in EXTENSIONS:
+            index.append(extract_metadata(fname))
+    os.makedirs('docs', exist_ok=True)
+    with open('docs/ontologies.json', 'w') as f:
+        json.dump(index, f, indent=2)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a generator script to collect ontology metadata
- generate an initial `docs/ontologies.json` index
- create a simple website in `docs/index.html`
- include placeholder SKOS taxonomy
- document how to build the index

## Testing
- `python3 scripts/generate_index.py`

------
https://chatgpt.com/codex/tasks/task_e_683d8c85ff108332a1428b0f9c75eee8