### PR TITLE
Fix GitHub action push

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- enable `contents: write` permission so auto-commit can push updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ded6a68808332b6e77bf6fb464f93