### PR TITLE
Add optional advanced ontology review workflow

### DIFF
--- a/.github/workflows/advanced-review.yml
+++ b/.github/workflows/advanced-review.yml
@@ -1,0 +1,24 @@
+name: Advanced Ontology Review
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run advanced review
+        run: python scripts/advanced_review.py
+      - name: Commit and push results
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'Update ontology metadata [skip ci]'
+          branch: ${{ github.ref }}
+          file_pattern: docs/ontologies.json

--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@
 Run `scripts/generate_index.py` to produce `docs/ontologies.json`. The `docs` directory hosts a simple index that can be served via GitHub Pages.
 
 A GitHub Actions workflow in `.github/workflows/update-pages.yml` automatically regenerates `docs/ontologies.json` and commits it when changes are pushed to `main`.
+
+## Advanced Review
+
+The optional workflow `advanced-review.yml` can be triggered manually to analyse
+ontology files and fill in any missing metadata in `docs/ontologies.json` such
+as primary and secondary use or relevance for project management. It runs
+`scripts/advanced_review.py` and commits the updated index back to the
+repository.

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,13 @@ function render() {
     if (!filter || o.name.toLowerCase().includes(filter) || o.type.includes(filter)) {
       const div = document.createElement('div');
       div.className = 'card';
-      div.innerHTML = `<h3>${o.name}</h3><p>${o.description}</p><p><a href="../${o.file}">${o.file}</a> (${o.type})</p>`;
+      div.innerHTML = `
+        <h3>${o.name}</h3>
+        <p>${o.description}</p>
+        <p><strong>Primary Use:</strong> ${o.primary_use || ''}</p>
+        <p><strong>Secondary Use:</strong> ${o.secondary_use || ''}</p>
+        <p><a href="../${o.file}">${o.file}</a> (${o.file_type || o.type})</p>
+        <p><strong>Relevance:</strong> ${o.relevance || ''}</p>`;
       container.appendChild(div);
     }
   });

--- a/docs/ontologies.json
+++ b/docs/ontologies.json
@@ -3,276 +3,460 @@
     "file": "2020BFOeasier.ttl",
     "type": "ttl",
     "name": "BFO 2020",
-    "description": ""
+    "description": "",
+    "file_type": "ttl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "2020_02_philosophy_inpho.owl",
     "type": "owl",
     "name": "2020_02_philosophy_inpho",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "2020_11_Philosphy inpho.owl",
     "type": "owl",
     "name": "2020_11_Philosphy inpho",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "2022 11 safety ontology.ttl",
     "type": "ttl",
     "name": "2022 11 safety ontology",
-    "description": ""
+    "description": "",
+    "file_type": "ttl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "2022 useful ontologies from protege.txt",
     "type": "txt",
     "name": "2022 useful ontologies from protege",
-    "description": ""
+    "description": "",
+    "file_type": "txt",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "BFO2020.rdf",
     "type": "rdf",
     "name": "BFO2020",
-    "description": ""
+    "description": "",
+    "file_type": "rdf",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "BFO2020_betterlabels.owl",
     "type": "owl",
     "name": "BFO 2020",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "Decisions.owl.txt",
     "type": "txt",
     "name": "Decisions.owl",
-    "description": ""
+    "description": "",
+    "file_type": "txt",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "From_archimate_insurance.owl",
     "type": "owl",
     "name": "From_archimate_insurance",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "Innovation0_gi2mo.owl",
     "type": "owl",
     "name": "Innovation0_gi2mo",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "medium"
   },
   {
     "file": "IoTFrameworks.ttl.html",
     "type": "html",
     "name": "IoTFrameworks.ttl",
-    "description": ""
+    "description": "",
+    "file_type": "html",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "OntoAgile.owl.html",
     "type": "html",
     "name": "OntoAgile.owl",
-    "description": ""
+    "description": "",
+    "file_type": "html",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "P6_schema_as_cypher.txt",
     "type": "txt",
     "name": "P6_schema_as_cypher",
-    "description": ""
+    "description": "",
+    "file_type": "txt",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "SWO software ontology.owl",
     "type": "owl",
     "name": "SWO software ontology",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "SafetyOntology.owl",
     "type": "owl",
     "name": "SafetyOntology",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "bfo-2020.owl",
     "type": "owl",
     "name": "bfo-2020",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "bfo_classes_only.owl",
     "type": "owl",
     "name": "bfo_classes_only",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "building, planning, zoning, and land use regulation information in Finland.ttl",
     "type": "ttl",
     "name": "Kokoontumistilan henkil\u00f6m\u00e4\u00e4r\u00e4",
-    "description": "V\u00e4est\u00f6tietoj\u00e4rjestelm\u00e4\u00e4n tallennettu pysyv\u00e4 rakennustunnus."
+    "description": "V\u00e4est\u00f6tietoj\u00e4rjestelm\u00e4\u00e4n tallennettu pysyv\u00e4 rakennustunnus.",
+    "file_type": "ttl",
+    "primary_use": "V\u00e4est\u00f6tietoj\u00e4rjestelm\u00e4\u00e4n tallennettu pysyv\u00e4 rakennustunnus",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "config.owl",
     "type": "owl",
     "name": "config",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "cover for risk and value.ttl.txt",
     "type": "txt",
     "name": "Endurant",
-    "description": ""
+    "description": "",
+    "file_type": "txt",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "cover.ttl.txt",
     "type": "txt",
     "name": "Endurant",
-    "description": ""
+    "description": "",
+    "file_type": "txt",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "gistCore11.0.0.ttl",
     "type": "ttl",
     "name": "gistCore11.0.0",
-    "description": ""
+    "description": "",
+    "file_type": "ttl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "gistCore9.4.0.json",
     "type": "json",
     "name": "gistCore9.4.0",
-    "description": ""
+    "description": "",
+    "file_type": "json",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "gistCore9.4.0.rdf",
     "type": "rdf",
     "name": "gistCore9.4.0",
-    "description": ""
+    "description": "",
+    "file_type": "rdf",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "gistCore9.4.0.ttl",
     "type": "ttl",
     "name": "gistCore",
-    "description": "Gist is a minimalist upper ontology created by Semantic Arts"
+    "description": "Gist is a minimalist upper ontology created by Semantic Arts",
+    "file_type": "ttl",
+    "primary_use": "Gist is a minimalist upper ontology created by Semantic Arts",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "inpho_temp.ttl",
     "type": "ttl",
     "name": "inpho_temp",
-    "description": ""
+    "description": "",
+    "file_type": "ttl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "itpm_CommunicationsManagement.owl",
     "type": "owl",
     "name": "itpm_CommunicationsManagement",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "itpm_IT-PMV5.owl",
     "type": "owl",
     "name": "itpm_IT-PMV5",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "itpm_IssueConcepts(inwork).owl",
     "type": "owl",
     "name": "itpm_IssueConcepts(inwork)",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "itpm_KnowledgeBase.owl",
     "type": "owl",
     "name": "itpm_KnowledgeBase",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "itpm_QualityMGMT.owl",
     "type": "owl",
     "name": "itpm_QualityMGMT",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "itpm_RuleStructure.owl",
     "type": "owl",
     "name": "itpm_RuleStructure",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "itpm_ScopeManagement.owl",
     "type": "owl",
     "name": "itpm_ScopeManagement",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "itpm_TimeManagement.owl",
     "type": "owl",
     "name": "itpm_TimeManagement",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "kko.owl",
     "type": "owl",
     "name": "kko",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "ontouml.ttl.html",
     "type": "html",
     "name": "ontouml.ttl",
-    "description": ""
+    "description": "",
+    "file_type": "html",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "pmbok-event.owl",
     "type": "owl",
     "name": "pmbok-event",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "pmbok-ref.owl",
     "type": "owl",
     "name": "pmbok-ref",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "medium"
   },
   {
     "file": "pmbok-role.owl",
     "type": "owl",
     "name": "pmbok-role",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "medium"
   },
   {
     "file": "pmbok4.owl",
     "type": "owl",
     "name": "pmbok4",
-    "description": ""
+    "description": "",
+    "file_type": "owl",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "medium"
   },
   {
     "file": "super pattern.txt.txt",
     "type": "txt",
     "name": "super pattern.txt",
-    "description": ""
+    "description": "",
+    "file_type": "txt",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "temporal.xsd.xml",
     "type": "xml",
     "name": "temporal.xsd",
-    "description": ""
+    "description": "",
+    "file_type": "xml",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "temporal1.xsd.xml",
     "type": "xml",
     "name": "temporal1.xsd",
-    "description": ""
+    "description": "",
+    "file_type": "xml",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "temporalReferenceSystems.xsd.xml",
     "type": "xml",
     "name": "temporalReferenceSystems.xsd",
-    "description": ""
+    "description": "",
+    "file_type": "xml",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "temporalTopology.xsd.xml",
     "type": "xml",
     "name": "temporalTopology.xsd",
-    "description": ""
+    "description": "",
+    "file_type": "xml",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   },
   {
     "file": "uniclass1-4.rdf",
     "type": "rdf",
     "name": "uniclass1-4",
-    "description": ""
+    "description": "",
+    "file_type": "rdf",
+    "primary_use": "",
+    "secondary_use": "",
+    "relevance": "low"
   }
 ]

--- a/scripts/advanced_review.py
+++ b/scripts/advanced_review.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fill missing ontology metadata in docs/ontologies.json."""
+
+import json
+import os
+import re
+
+INDEX_PATH = os.path.join('docs', 'ontologies.json')
+
+# heuristics for extracting metadata
+
+def extract_name(content, fallback):
+    label_match = re.search(r'rdfs:label\s+["\']([^"\']+)["\']', content)
+    if label_match:
+        return label_match.group(1)
+    title_match = re.search(r'dc:title\s+["\']([^"\']+)["\']', content)
+    if title_match:
+        return title_match.group(1)
+    return fallback
+
+def extract_description(content):
+    desc_match = re.search(r'(?:rdfs:comment|dc:description|dct:description)\s+["\']([^"\']+)["\']', content, re.I)
+    if desc_match:
+        return desc_match.group(1)
+    return ''
+
+def infer_relevance(text):
+    ltext = text.lower()
+    if 'project management' in ltext:
+        return 'high'
+    if 'project' in ltext and 'management' in ltext:
+        return 'medium'
+    return 'low'
+
+def infer_use(description):
+    if not description:
+        return '', ''
+    parts = description.split('.')
+    primary = parts[0].strip()
+    secondary = '.'.join(p.strip() for p in parts[1:] if p.strip())
+    return primary, secondary
+
+def process_file(path, metadata):
+    try:
+        with open(path, 'r', errors='ignore') as f:
+            content = f.read(5000)
+    except Exception:
+        content = ''
+    metadata.setdefault('file_type', os.path.splitext(path)[1].lstrip('.').lower() or 'other')
+
+    if not metadata.get('name'):
+        metadata['name'] = extract_name(content, os.path.splitext(os.path.basename(path))[0])
+
+    desc = extract_description(content)
+    if not metadata.get('description'):
+        metadata['description'] = desc
+    primary, secondary = infer_use(desc)
+    if not metadata.get('primary_use'):
+        metadata['primary_use'] = primary
+    if not metadata.get('secondary_use'):
+        metadata['secondary_use'] = secondary
+    if not metadata.get('relevance'):
+        metadata['relevance'] = infer_relevance(content)
+
+    return metadata
+
+def main():
+    if not os.path.exists(INDEX_PATH):
+        raise FileNotFoundError(INDEX_PATH)
+
+    with open(INDEX_PATH, 'r') as f:
+        index = json.load(f)
+
+    for entry in index:
+        file_path = entry.get('file')
+        if not file_path:
+            continue
+        entry = process_file(file_path, entry)
+
+    with open(INDEX_PATH, 'w') as f:
+        json.dump(index, f, indent=2)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- expand ontology metadata page to display new optional fields
- add optional workflow to run advanced ontology review
- add script that fills blank metadata fields
- document the new workflow

## Testing
- `python scripts/advanced_review.py`

------
https://chatgpt.com/codex/tasks/task_e_683df7fd44d083328ee1507a76c06c66