### PR TITLE
Enhance index site and add taxonomy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ ontology files and fill in any missing metadata in `docs/ontologies.json` such
 as primary and secondary use or relevance for project management. It runs
 `scripts/advanced_review.py` and commits the updated index back to the
 repository.
+
+## Taxonomy Generation
+
+Run `scripts/generate_taxonomy.py` after the index is updated to rebuild
+`docs/taxonomy.ttl` with SKOS concepts for each ontology file type. This keeps
+the taxonomy in sync with the available ontologies.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,19 +5,47 @@
 <title>Ontologies Index</title>
 <meta name="description" content="Index of ontologies for projects">
 <meta name="keywords" content="ontology, project">
+<!-- Google tag (gtag.js) placeholder -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-XXXXXXX');
+</script>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Dataset",
+  "name": "Ontologies Index",
+  "description": "Index of ontologies for projects",
+  "url": "https://example.org"
+}
+</script>
 <script>
 async function load() {
   const resp = await fetch('ontologies.json');
   const data = await resp.json();
   window.ontologies = data;
+  populateTypes();
   render();
 }
+
+function populateTypes() {
+  const select = document.getElementById('typeFilter');
+  const types = Array.from(new Set(ontologies.map(o => (o.file_type || o.type)))).sort();
+  select.innerHTML = '<option value="">All Types</option>' +
+    types.map(t => `<option value="${t}">${t}</option>`).join('');
+}
+
 function render() {
   const filter = document.getElementById('filter').value.toLowerCase();
+  const type = document.getElementById('typeFilter').value.toLowerCase();
   const container = document.getElementById('cards');
   container.innerHTML = '';
   ontologies.forEach(o => {
-    if (!filter || o.name.toLowerCase().includes(filter) || o.type.includes(filter)) {
+    const oType = (o.file_type || o.type).toLowerCase();
+    if ((!filter || o.name.toLowerCase().includes(filter)) && (!type || oType === type)) {
       const div = document.createElement('div');
       div.className = 'card';
       div.innerHTML = `
@@ -41,6 +69,7 @@ body { font-family: Arial, sans-serif; }
 <body>
 <h1>Ontologies</h1>
 <input id="filter" placeholder="Filter" oninput="render()">
+<select id="typeFilter" onchange="render()"></select>
 <div id="cards"></div>
 </body>
 </html>

--- a/docs/taxonomy.ttl
+++ b/docs/taxonomy.ttl
@@ -1,6 +1,25 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
-# Placeholder taxonomy that can be expanded as ontologies are added.
+<http://example.org/taxonomy#OntologyTypes> a skos:ConceptScheme ;
+    skos:prefLabel "Ontology File Types" .
 
-<http://example.org/taxonomy> a skos:ConceptScheme ;
-    skos:prefLabel "Ontology Topics" .
+<http://example.org/taxonomy#owl> a skos:Concept ;
+    skos:prefLabel "owl" ;
+    skos:inScheme <http://example.org/taxonomy#OntologyTypes> .
+
+<http://example.org/taxonomy#rdf> a skos:Concept ;
+    skos:prefLabel "rdf" ;
+    skos:inScheme <http://example.org/taxonomy#OntologyTypes> .
+
+<http://example.org/taxonomy#ttl> a skos:Concept ;
+    skos:prefLabel "ttl" ;
+    skos:inScheme <http://example.org/taxonomy#OntologyTypes> .
+
+<http://example.org/taxonomy#txt> a skos:Concept ;
+    skos:prefLabel "txt" ;
+    skos:inScheme <http://example.org/taxonomy#OntologyTypes> .
+
+<http://example.org/taxonomy#xml> a skos:Concept ;
+    skos:prefLabel "xml" ;
+    skos:inScheme <http://example.org/taxonomy#OntologyTypes> .
+

--- a/scripts/generate_taxonomy.py
+++ b/scripts/generate_taxonomy.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Generate simple SKOS taxonomy from ontologies index."""
+
+import json
+import os
+
+INDEX = os.path.join('docs', 'ontologies.json')
+OUTPUT = os.path.join('docs', 'taxonomy.ttl')
+
+PREFIX = "http://example.org/taxonomy#"
+
+
+def main():
+    with open(INDEX, 'r') as f:
+        data = json.load(f)
+
+    types = sorted(set((entry.get('file_type') or entry['type']) for entry in data))
+
+    with open(OUTPUT, 'w') as f:
+        f.write('@prefix skos: <http://www.w3.org/2004/02/skos/core#> .\n\n')
+        f.write(f'<{PREFIX}OntologyTypes> a skos:ConceptScheme ;\n')
+        f.write('    skos:prefLabel "Ontology File Types" .\n\n')
+        for t in types:
+            cid = t.replace(' ', '_')
+            f.write(f'<{PREFIX}{cid}> a skos:Concept ;\n')
+            f.write(f'    skos:prefLabel "{t}" ;\n')
+            f.write(f'    skos:inScheme <{PREFIX}OntologyTypes> .\n\n')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- include Google tag placeholder and schema.org markup
- add file type dropdown filter to the index
- script for generating taxonomy
- document taxonomy script and regenerate taxonomy

## Testing
- `python3 scripts/generate_taxonomy.py`


------
https://chatgpt.com/codex/tasks/task_e_683e1621fda88332a4f8604126789141