### PR TITLE
Fix workflow to stop auto index generation

### DIFF
--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -1,0 +1,24 @@
+name: Generate Ontology Index
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Generate index
+        run: python scripts/generate_index.py
+      - name: Commit and push
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'Generate ontologies index [skip ci]'
+          branch: ${{ github.ref }}
+          file_pattern: docs/ontologies.json

--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -14,15 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - name: Generate index
-        run: python scripts/generate_index.py
-      - name: Commit and push
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: 'Update ontologies index [skip ci]'
-          branch: ${{ github.ref }}
-          file_pattern: docs/ontologies.json
+      - name: Build site
+        run: echo "Updating GitHub Pages without regenerating index"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Run `scripts/generate_index.py` to produce `docs/ontologies.json`. The `docs` directory hosts a simple index that can be served via GitHub Pages.
 
-A GitHub Actions workflow in `.github/workflows/update-pages.yml` automatically regenerates `docs/ontologies.json` and commits it when changes are pushed to `main`.
+Use the `generate-index` workflow to regenerate `docs/ontologies.json` when needed. This workflow can be triggered manually and commits the updated file back to the repository. The `update-pages` workflow no longer modifies the index automatically.
 
 ## Advanced Review
 


### PR DESCRIPTION
## Summary
- decouple index generation from pages workflow
- document new `generate-index` workflow
- add workflow for manual index generation

## Testing
- `python scripts/generate_index.py`

------
https://chatgpt.com/codex/tasks/task_e_683e1def826c8332a998e0dbe0d844a5